### PR TITLE
Add PLANE-X Mapping

### DIFF
--- a/api/mapping.ts
+++ b/api/mapping.ts
@@ -314,4 +314,23 @@ export const stakePoolMetadatas: StakePoolMetadata[] = [
     },
     notFound: true,
   },
+  {
+    name: 'plane-x',
+    displayName: 'PLANE-X',
+    stakePoolAddress: new PublicKey(
+      '5oaTiYTSuz5HwcFSFyZ3FXGMaAtV8UgKvAUFTdi8gS7y'
+    ),
+    websiteUrl: 'https://plane-x.io/',
+    receiptType: ReceiptType.Original,
+    maxStaked: 3333,
+    imageUrl: 'https://arweave.net/HpdUi39S2ixPus6cU74LeoXaKwWcxezIUTQkvVV9XKs',
+    redirect: 'https://staking.plane-x.io/',
+    colors: {
+      primary: '#000000',
+      secondary: '#803499',
+      accent: '#803499',
+      fontColor: '#FFFFFF',
+    },
+    notFound: true,
+  },
 ]


### PR DESCRIPTION
Hi Cardinal team & repo manager, kindly help to review and merge these changes.
Adding PLANE-X metadata to the Cardinal Staking main page.

![image](https://user-images.githubusercontent.com/84768757/172150556-965be736-a1dd-4be7-8412-8a414210df52.png)

Thanks in advance, and thank you so much for building this feature it's very handy.