### PR TITLE
Customized Staking URL + mapping.tsx Staking Sweet Apocalypse integration + Pages/StakepoolID/index.tsx 3 code lines additionally

### DIFF
--- a/api/mapping.ts
+++ b/api/mapping.ts
@@ -1231,4 +1231,58 @@ export const stakePoolMetadatas: StakePoolMetadata[] = [
       fontColor: '#f2edd4',
     },
   },
+  {
+    name: 'Sweet-Apocalypse',
+    displayName: 'Sweet Apocalypse',
+    nameInHeader: true,
+    stakePoolAddress: new PublicKey(
+      'GzmFJFc7rZpULuJMhs8XRRxnEFFCJi4U5YFnUPZsuHPN'
+    ),
+    receiptType: ReceiptType.Original,
+    tokenStandard: TokenStandard.NonFungible,
+    hideAllowedTokens: true,
+    // styles to apply to the whole stake pool
+    styles: {
+      fontFamily: 'Industry, sans-serif',
+      fontWeight: 700,
+      fontSize: '22px',  
+      font: '#000000',
+      color: '#000000',
+  
+    },
+    // Colors object to style the stake page
+    colors: {
+      primary: 'rgb(120 122 108 / 80%)',
+      secondary: '#F9C90C',
+      backgroundSecondary: 'rgb(61 169 211 / 65%)',
+      fontColor: '#ffff',
+      fontColorSecondary: '#000000',
+    },
+    imageUrl:'https://bafkreie5parsjwtmnk7cyixtdoznifdk3hx2kjazzrvecc3mgjrwvr6tfy.ipfs.nftstorage.link/',
+    // Background image for poolq
+    backgroundImage:'https://bafybeifddabmgm3rinrdngbzanttwxp2qfr5ffpu7itgradc4sxplpjvc4.ipfs.nftstorage.link/',
+   
+
+    // Website url if specified will be navigated to when the image in the header is clicked
+    websiteUrl: 'https://www.sweetapocalypse.org/',
+    maxStaked: 6666,
+    links: [
+      {
+        text: 'Twitter',
+        value: 'https://twitter.com/sweetapocaIypse',
+      },
+      {
+        text: 'Discord',
+        value: 'https://discord.gg/sweetapocalypse',
+      },
+      {
+        text: 'Sweet Apocalypse',
+        value: 'https://www.sweetapocalypse.org/',
+      },
+      {
+        text: 'MINT',
+        value: 'https://www.sweetapomint.org/',
+      },
+    ],
+  }
 ]

--- a/next.config.js
+++ b/next.config.js
@@ -25,6 +25,10 @@ const HOST_MAPPINGS = [
     name: 'rebellionbots',
     hostname: 'stake.rebellionbots.io',
   },
+    {
+    name: 'Sweet-Apocalypse',
+    hostname: 'stake.sweetapocalypse.org',
+  },
 ]
 
 /** @type {import('next').NextConfig} */

--- a/pages/[stakePoolId]/index.tsx
+++ b/pages/[stakePoolId]/index.tsx
@@ -541,9 +541,12 @@ function Home() {
 
   return (
     <div
-      style={{
+       style={{
         background: stakePoolMetadata?.colors?.primary,
-        backgroundImage: `url(${stakePoolMetadata?.backgroundImage})`,
+        backgroundImage: url(${stakePoolMetadata?.backgroundImage}),
+        backgroundSize: 'cover',
+        backgroundPosition:'center',
+        backgroundRepeat:'no-repeat',
       }}
     >
       <Head>


### PR DESCRIPTION
Hi I am new to this coding. I added our staking information to the mapping.tsx at the end + a customized URL to the next.config.js.

Additionally I added three codes in the Page/StakepoolID/index.tsx:
 **backgroundSize: 'cover',
        backgroundPosition:'center',
        backgroundRepeat:'no-repeat'**,

This will help any backgroundImage -- ULR upload in the mapping.tsx to find the right sizing for the window. Withtout adding this three lines the images will always overflow the window or do other unpredicatable behaviour.
I hope you ll integrate it and  you ll see the difference after on our staking page with the mountain image.
Kind regards,
Chippu from Discord